### PR TITLE
don't remove libiberty.a

### DIFF
--- a/avr-gdb.rb
+++ b/avr-gdb.rb
@@ -17,9 +17,5 @@ class AvrGdb < Formula
                           "--program-prefix=avr-"
     system "make"
     system "make install"
-
-    # binutils already has a libiberty.a. We remove ours, because
-    # otherwise, the symlinking of the keg fails
-    File.unlink "#{prefix}/lib/#{multios}/libiberty.a"
   end
 end


### PR DESCRIPTION
on my machine (Mac OS X 10.10 Yosemite), compiling gdb will not create a libiberty.a
in {path}/lib/{multios}/libiberty.a, so unlinking it results in an error. this fixes issue #4.